### PR TITLE
Implement project.toml processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+HOST_PORT?=8080
+TEST_IMAGE_PREFIX?=sample
+
+.PHONY: build
+build:
+	docker build --progress=plain -t erichripko/cnbp .
+
+.PHONY: test
+test:
+	go test -v ./...
+
+.PHONY: e2e-sample-ruby-bundler
+e2e-sample-ruby-bundler: e2e-sample-ruby-bundler-build e2e-sample-ruby-bundler-run
+
+.PHONY: e2e-sample-ruby-bundler-build
+e2e-sample-ruby-bundler-build: export TEST_IMAGE_NAME:=$(TEST_IMAGE_PREFIX)-ruby-app
+e2e-sample-ruby-bundler-build:
+	@echo "> Building $(TEST_IMAGE_NAME)..."
+	docker build --progress=plain -t $(TEST_IMAGE_NAME) -f samples/ruby-bundler/project.toml samples/ruby-bundler/
+
+.PHONY: e2e-sample-ruby-bundler-run
+e2e-sample-ruby-bundler-run: export TEST_IMAGE_NAME:=$(TEST_IMAGE_PREFIX)-ruby-app
+e2e-sample-ruby-bundler-run:
+	@echo "> Running $(TEST_IMAGE_NAME) on PORT $(HOST_PORT)..."
+	@ID=`docker run -d --rm -it -p 8080:8080 $(TEST_IMAGE_NAME) /cnb/lifecycle/launcher`; \
+	until CONTENTS=`curl -s http://localhost:8080`; do sleep 2; done; echo $$CONTENTS; \
+	docker stop $$ID > /dev/null
+
+.PHONY: clear-build-cache
+clear-build-cache:
+	docker builder prune -f

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ but is not there yet.
 
 ```dockerfile
 # syntax = erichripko/cnbp
-paketobuildpacks/builder:full
+[io.buildpacks.build]
+builder = "some-builder"
 ```
 
 - Build it

--- a/cmd/cnbp-frontend/frontend.go
+++ b/cmd/cnbp-frontend/frontend.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/EricHripko/cnbp/pkg/cib"
 	"github.com/EricHripko/cnbp/pkg/cnbp2llb"
+	"github.com/EricHripko/cnbp/pkg/config"
 	"github.com/containerd/containerd/platforms"
 
 	"github.com/moby/buildkit/client/llb"
@@ -66,15 +66,14 @@ func BuildWithService(ctx context.Context, c client.Client, svc cib.Service) (*c
 				if err != nil {
 					return err
 				}
-				builder := strings.TrimSpace(string(dtMetadata))
-				if strings.Contains(builder, "\n") {
-					// Strip BuildKit syntax comment
-					lines := strings.Split(builder, "\n")
-					builder = lines[len(lines)-1]
+
+				buildCfg, err := config.FromProjectTOML(string(dtMetadata))
+				if err != nil {
+					return err
 				}
 
 				// Prepare build environment
-				env, err := cnbp2llb.BuildEnvironment(ctx, svc, tp, builder)
+				env, err := cnbp2llb.BuildEnvironment(ctx, svc, tp, buildCfg.Builder())
 				if err != nil {
 					return errors.Wrap(err, "cannot prepare environment")
 				}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/pelletier/go-toml v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -732,6 +732,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
+github.com/pelletier/go-toml v1.9.0 h1:NOd0BRdOKpPf0SxkL3HxSQOG7rNh+4kl6PHcBPFs7Q0=
+github.com/pelletier/go-toml v1.9.0/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/cnbp2llb/export.go
+++ b/pkg/cnbp2llb/export.go
@@ -35,6 +35,7 @@ func Export(ctx context.Context, build cib.Service, built llb.State, cache llb.R
 		// Mount frontend for the cacher binary
 		llb.AddMount(
 			"/frontend",
+			// TODO: can we make this dynamic
 			llb.Image("erichripko/cnbp"),
 		),
 		cache,
@@ -130,6 +131,7 @@ func Export(ctx context.Context, build cib.Service, built llb.State, cache llb.R
 			llb.WithCustomNamef("Exporting buildpack layer %s", layer),
 		)
 	}
+
 	// Must contain one or more app layers
 	state = state.File(
 		llb.Copy(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/query"
+	"github.com/pkg/errors"
+)
+
+type Config interface {
+	Builder() string
+	PreviousImage() string
+}
+
+type config struct {
+	builder   string
+	prevImage string
+}
+
+func (c *config) Builder() string {
+	return c.builder
+}
+
+func (c *config) PreviousImage() string {
+	return c.prevImage
+}
+
+type buildKitOpts struct {
+	PreviousImage string `toml:"previous-image"`
+}
+
+func FromProjectTOML(data string) (Config, error) {
+	tree, err := toml.Load(data)
+	if err != nil {
+		return &config{}, err
+	}
+
+	builder, err := extractBuilder(tree)
+	if err != nil {
+		return &config{}, err
+	}
+
+	buildKitOpts, err := extractBuildKitOptions(tree)
+	if err != nil {
+		return &config{}, err
+	}
+
+	return &config{
+		builder:   builder,
+		prevImage: buildKitOpts.PreviousImage,
+	}, nil
+}
+
+func extractBuilder(tree *toml.Tree) (string, error) {
+	builder, err := extractString(tree, "$.io.buildpacks.build.builder")
+	if err != nil {
+		return "", err
+	}
+
+	if builder == "" {
+		return "", errors.New("no builder provided")
+	}
+
+	return builder, err
+}
+
+func extractBuildKitOptions(tree *toml.Tree) (*buildKitOpts, error) {
+	opts := &buildKitOpts{}
+	results, err := query.CompileAndExecute("$.io.buildpacks.ext.buildkit", tree)
+	if err != nil {
+		return opts, errors.Wrap(err, "failed finding '$.io.buildpacks.ext.buildkit'")
+	}
+
+	if len(results.Values()) == 0 {
+		return opts, nil
+	}
+
+	optsTree := results.Values()[0].(*toml.Tree)
+
+	err = optsTree.Unmarshal(opts)
+	if err != nil {
+		return opts, errors.Wrap(err, "failed to parse '$.io.buildpacks.ext.buildkit' value")
+	}
+
+	return opts, nil
+}
+
+func extractString(tree *toml.Tree, path string) (string, error) {
+	results, err := query.CompileAndExecute(path, tree)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed finding '%s'", path)
+	}
+
+	if len(results.Values()) == 0 {
+		return "", nil
+	}
+
+	return results.Values()[0].(string), nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromProjectTOML(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data string
+		want Config
+	}{
+		{
+			name: "Full sample",
+			data: `# syntax = erichripko/cnbp
+			[_]
+			api = "0.2"
+			id = "my-app"
+			name = "My App"
+			
+			[io.buildpacks]
+			api = "0.1"
+			
+			[io.buildpacks.build]
+			builder = "some-builder"
+			
+			[io.buildpacks.ext.buildkit]
+			previous-image = "prev-app-image"
+			`,
+			want: &config{
+				builder:   "some-builder",
+				prevImage: "prev-app-image",
+			},
+		}, {
+			name: "Minimal sample",
+			data: `# syntax = erichripko/cnbp
+			[io.buildpacks.build]
+			builder = "some-builder"
+			`,
+			want: &config{
+				builder: "some-builder",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := FromProjectTOML(tt.data)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FromProjectTOML() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name: "Builder is required",
+			data: `# syntax = erichripko/cnbp
+			`,
+			wantErr: "no builder provided",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FromProjectTOML(tt.data)
+			if err.Error() != tt.wantErr {
+				t.Errorf("FromProjectTOML() = %+v error = %v, wantErr = %v", got, err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/samples/ruby-bundler
+++ b/samples/ruby-bundler
@@ -1,0 +1,1 @@
+../../../buildpacks/samples/apps/ruby-bundler/


### PR DESCRIPTION
This change also includes a minimal sample ruby app for testing and e2e targets in Makefile to improve the development feedback loop.

NOTE: I haven't fully implemented or explored additional options that may reside under `io.buildpacks.ext.buildkit`. As of right now I added "previous image" with the hope of being able to target and gather information from an existing image on the daemon as part of the  `analyze`  phase.

NOTE 2: The config package could also be responsible for resolving the final configuration to use as part of the BuildKit process by merging all possible configuration mechanisms into a final resolved data type. For example, `build-args` + `project.toml` + `env vars` = "resolved config".