### PR TITLE
Improve docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing Guide
+
+You're welcome to contribute in whatever way you can. To make sure that
+contributing is a good experience for everyone, please submit an issue to
+discuss the change ahead of implementing (if appropriate and possible).
+
+## 📋 Prerequisites
+
+- Go of version `1.15` or later (get it [here](https://golang.org/doc/install))
+- Docker with BuildKit support enabled (see [docs](https://docs.docker.com/develop/develop-images/build_enhancements/))
+
+## 💻 Develop
+
+- Clone the repository: `git clone https://github.com/EricHripko/cnbp.git`
+- Edit away in your favourite environment
+
+## 🏗️ Build
+
+- Check that the code builds: `go build ./...`
+- Build the frontend: `docker build -t erichripko/cnbp .`
+
+## ✅ Verify
+
+- Verify functionality with tests: `go test ./...`
+  - This will run unit tests against the components
+  - This will run end-to-end tests against the frontend
+
+## 🔬 Analyse
+
+- Code is formatted with standard Go tooling: `go fmt ./...`
+- Code is linted with [golangci-lint](https://golangci-lint.run/): `golangci-lint run`
+
+## 📢 Publish
+
+Once the PR is landed, [GitHub Actions](https://github.com/features/actions)
+will automatically publish the release of the frontend to
+[Docker Hub](https://hub.docker.com/).
+
+## 😀 Release
+
+The frontend is referenced directly from _Docker Hub_, so it's immediately
+released for everyone once published. `docker pull erichripko/cnbp` might be
+necessary to get the latest version of the frontend if an older version is
+already stored on the daemon.

--- a/README.md
+++ b/README.md
@@ -6,21 +6,15 @@ since BuildKit [doesn't support Windows yet](https://github.com/moby/buildkit/is
 Frontend aims to implement [Platform API 0.5](https://github.com/buildpacks/spec/),
 but is not there yet.
 
-## How to build it
-
-- Clone the repository
-- Build the frontend image: `docker build -t erichripko/cnbp .`
-
 ## How to try it
 
 - Make sure that BuildKit is enabled in your daemon
 - Clone CNBP [samples repository](https://github.com/buildpacks/samples)
-- Add the following lines to the `Dockerfile`. As you can see, the only
-  content apart from the syntax stanza should be the name of the builder
-  to be used. This corresponds to `<image-name>` of
-  `pack build <image-name> [flags]` invocation.
+- Add the following lines to the [project.toml](https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/).
+  `builder` corresponds to `--builder` flag of `pack build <image-name> [flags]`
+  invocation.
 
-```dockerfile
+```toml
 # syntax = erichripko/cnbp
 [io.buildpacks.build]
 builder = "some-builder"


### PR DESCRIPTION
# Overview
Improve docs for contributors and end users. For the former, there's now a complete _Contributing Guide_. For the latter, `project.toml` is now suggested for specifying the builder (as per #1).